### PR TITLE
= 대신 == 사용

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 keras==2.2.4
-tensorflow=1.14.0
+tensorflow==1.14.0
 mpl_finance


### PR DESCRIPTION
`requirements.txt`에서 특정 버전의 라이브러리를 사용하기 위해 `=` 대신 `==` 연산자를 사용합니다.